### PR TITLE
feat: allow to set SIP credential in API request

### DIFF
--- a/src/service/commander_service.ts
+++ b/src/service/commander_service.ts
@@ -218,8 +218,12 @@ export class CommanderService {
             }
 
             if (startComponentRequest.sipClientParams) {
-                startComponentRequest.sipClientParams.userName = this.sipClientUsername;
-                startComponentRequest.sipClientParams.password = this.sipClientPassword;
+                if (!startComponentRequest.sipClientParams.userName) {
+                    startComponentRequest.sipClientParams.userName = this.sipClientUsername;
+                }
+                if (!startComponentRequest.sipClientParams.password) {
+                    startComponentRequest.sipClientParams.password = this.sipClientPassword;
+                }
             }
 
             try {


### PR DESCRIPTION
Normally, `sidecar` gets the SIP credential from `/etc/jitsi/sidecar/env`. This commit allows user to set SIP credential in API request too. If the credential is not set in the API request, the old behaviour still works.

So, no need to update the sidecar `env` file if the user want to use different credentials for different sessions.

A sample request:

```
{
...
  "metadata": {
    "sipClientParams": {
      "userName": "1000@sip.mydomain.corp",
      "password": "mysippassword",
      "sipAddress": "sip:1001@sip.mydomain.corp",
      ...
      ...
    }
  }
...
}
```